### PR TITLE
Bugfix/devsu 2348 add gene assoc to pharmacogenelist

### DIFF
--- a/pori_python/graphkb/genes.py
+++ b/pori_python/graphkb/genes.py
@@ -226,10 +226,19 @@ def get_preferred_gene_name(
     return gene_names[0]
 
 
-# DEVSU-2348 - relate the genes to the variants
 def get_cancer_predisposition_info(
     conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE
 ) -> Tuple[List[str], Dict[str, str]]:
+    newval = get_gene_linked_cancer_predisposition_info(conn, source)
+    genes = newval[0]
+    allvardata = newval[1]
+    variants = {key: allvardata[key][0] for key in allvardata.keys()}
+    return newval[0], variants
+
+
+def get_gene_linked_cancer_predisposition_info(
+    conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE
+) -> Tuple[List[str], Dict[str, Tuple[str, List[str]]]]:
     """
     Return two lists from GraphKB, one of cancer predisposition genes and one of associated variants.
 
@@ -241,6 +250,8 @@ def get_cancer_predisposition_info(
     * gene is gotten from any associated 'PositionalVariant' records
 
     Example: https://graphkb.bcgsc.ca/view/Statement/155:11616
+
+
 
     Returns:
         genes: list of cancer predisposition genes
@@ -284,21 +295,24 @@ def get_cancer_predisposition_info(
     ):
         for condition in record["conditions"]:  # type: ignore
             if condition["@class"] == "PositionalVariant":
-                variants[condition["@rid"]] = condition["displayName"]
+                assoc_gene_list = []
                 for reference in ["reference1", "reference2"]:
                     name = (condition.get(reference) or {}).get("displayName", "")
                     biotype = (condition.get(reference) or {}).get("biotype", "")
                     if name and biotype == "gene":
                         genes.add(name)
+                        assoc_gene_list.append(name)
                     elif name:
                         gene = get_preferred_gene_name(conn, name, source)
                         if gene:
                             infer_genes.add((gene, name, biotype))
+                            assoc_gene_list.append(gene)
                         else:
                             non_genes.add((name, biotype))
                             logger.error(
                                 f"Non-gene cancer predisposition {biotype}: {name} for {condition['displayName']}"
                             )
+                variants[condition["@rid"]] = [condition["displayName"], assoc_gene_list]
 
     for gene, name, biotype in infer_genes:
         logger.debug(f"Found gene '{gene}' for '{name}' ({biotype})")
@@ -310,10 +324,19 @@ def get_cancer_predisposition_info(
     return sorted(genes), variants
 
 
-# DEVSU-2348 - relate the genes to the variants
 def get_pharmacogenomic_info(
     conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE
 ) -> Tuple[List[str], Dict[str, str]]:
+    newval = get_gene_linked_pharmacogenomic_info(conn, source)
+    genes = newval[0]
+    allvardata = newval[1]
+    variants = {key: allvardata[key][0] for key in allvardata.keys()}
+    return newval[0], variants
+
+
+def get_gene_linked_pharmacogenomic_info(
+    conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE
+) -> Tuple[List[str], Dict[str, Tuple[str, List[str]]]]:
     """
     Return two lists from GraphKB, one of pharmacogenomic genes and one of associated variants.
 
@@ -362,22 +385,24 @@ def get_pharmacogenomic_info(
 
         for condition in record["conditions"]:  # type: ignore
             if condition["@class"] == "PositionalVariant":
-                variants[condition["@rid"]] = condition["displayName"]
+                assoc_gene_list = []
                 for reference in ["reference1", "reference2"]:
                     name = (condition.get(reference) or {}).get("displayName", "")
                     biotype = (condition.get(reference) or {}).get("biotype", "")
                     if name and biotype == "gene":
                         genes.add(name)
+                        assoc_gene_list.append(name)
                     elif name:
                         gene = get_preferred_gene_name(conn, name, source)
                         if gene:
                             infer_genes.add((gene, name, biotype))
+                            assoc_gene_list.append(gene)
                         else:
                             non_genes.add((name, biotype))
                             logger.error(
                                 f"Non-gene pharmacogenomic {biotype}: {name} for {condition['displayName']}"
                             )
-
+                variants[condition["@rid"]] = [condition["displayName"], assoc_gene_list]
     for gene, name, biotype in infer_genes:
         logger.debug(f"Found gene '{gene}' for '{name}' ({biotype})")
         genes.add(gene)

--- a/tests/test_graphkb/test_genes.py
+++ b/tests/test_graphkb/test_genes.py
@@ -10,11 +10,13 @@ from pori_python.graphkb import GraphKBConnection
 from pori_python.graphkb.genes import (
     get_cancer_genes,
     get_cancer_predisposition_info,
+    get_gene_linked_cancer_predisposition_info,
     get_gene_information,
     get_genes_from_variant_types,
     get_oncokb_oncogenes,
     get_oncokb_tumour_supressors,
     get_pharmacogenomic_info,
+    get_gene_linked_pharmacogenomic_info,
     get_preferred_gene_name,
     get_therapeutic_associated_genes,
 )
@@ -141,7 +143,6 @@ def test_cancer_genes(conn):
         assert gene not in names
 
 
-@pytest.mark.skip(reason="DEVSU-2348")
 def test_get_pharmacogenomic_info(conn):
     genes, matches = get_pharmacogenomic_info(conn)
     for gene in PHARMACOGENOMIC_INITIAL_GENES:
@@ -150,12 +151,34 @@ def test_get_pharmacogenomic_info(conn):
             if variant_display.startswith(gene):
                 break
         else:  # no break called
+            # failing on this version of the func; addressed in 'new' version
+            if gene == 'ACYP2':
+                continue
+            assert False, f"No rid found for a pharmacogenomic with {gene}"
+
+
+def test_get_gene_linked_pharmacogenomic_info(conn):
+    genes, matches = get_gene_linked_pharmacogenomic_info(conn)
+    for gene in PHARMACOGENOMIC_INITIAL_GENES:
+        assert gene in genes, f"{gene} not found in get_pharmacogenomic_info"
+        for rid, variant_info in matches.items():
+            variant_gene_assoc = variant_info[1]
+            if gene in variant_gene_assoc:
+                break
+        else:  # no break called
             assert False, f"No rid found for a pharmacogenomic with {gene}"
 
 
 @pytest.mark.skipif(EXCLUDE_INTEGRATION_TESTS, reason="excluding long running integration tests")
 def test_get_cancer_predisposition_info(conn):
     genes, matches = get_cancer_predisposition_info(conn)
+    for gene in CANCER_PREDISP_INITIAL_GENES:
+        assert gene in genes, f"{gene} not found in get_cancer_predisposition_info"
+
+
+@pytest.mark.skipif(EXCLUDE_INTEGRATION_TESTS, reason="excluding long running integration tests")
+def test_get_gene_linked_cancer_predisposition_info(conn):
+    genes, matches = get_gene_linked_cancer_predisposition_info(conn)
     for gene in CANCER_PREDISP_INITIAL_GENES:
         assert gene in genes, f"{gene} not found in get_cancer_predisposition_info"
 


### PR DESCRIPTION
Adds new functions get_gene_linked_pharmacogenomic_info and get_gene_linked_cancer_predisposition_info, which provide clear links between genes and variants to deal with the situation where the variant name does not include the gene name. Existing functions get_pharmacogenomic_info and get_cancer_predisposition_info are updated to pull from the results of these functions.