### PR TITLE
add list sorting to equality check

### DIFF
--- a/tests/test_ipr/test_upload.py
+++ b/tests/test_ipr/test_upload.py
@@ -4,8 +4,8 @@ import pandas as pd
 import pytest
 import sys
 import uuid
-from typing import Dict
-from unittest.mock import patch
+from typing import Dict, Tuple, List
+from unittest.mock import MagicMock, patch
 
 from pori_python.ipr.connection import IprConnection
 from pori_python.ipr.main import command_interface
@@ -29,7 +29,6 @@ def get_test_spec():
 def get_test_file(name: str) -> str:
     return os.path.join(os.path.dirname(__file__), "test_data", name)
 
-
 @pytest.fixture(scope="module")
 def loaded_reports(tmp_path_factory) -> Dict:
     json_file = tmp_path_factory.mktemp("inputs") / "content.json"
@@ -41,7 +40,10 @@ def loaded_reports(tmp_path_factory) -> Dict:
             {"analysisRole": "expression (disease)", "name": "1"},
             {"analysisRole": "expression (primary site)", "name": "2"},
             {"analysisRole": "expression (biopsy site)", "name": "3"},
-            {"analysisRole": "expression (internal pancancer cohort)", "name": "4"},
+            {
+                "analysisRole": "expression (internal pancancer cohort)",
+                "name": "4",
+            },
         ],
         "patientId": patient_id,
         "project": "TEST",
@@ -80,10 +82,20 @@ def loaded_reports(tmp_path_factory) -> Dict:
         ),
         "kbDiseaseMatch": "colorectal cancer",
     }
-    json_file.write_text(json.dumps(json_contents, allow_nan=False))
+    json_file.write_text(
+        json.dumps(
+            json_contents,
+            allow_nan=False,
+        )
+    )
 
     json_contents["patientId"] = async_patient_id
-    async_json_file.write_text(json.dumps(json_contents, allow_nan=False))
+    async_json_file.write_text(
+        json.dumps(
+            json_contents,
+            allow_nan=False,
+        )
+    )
 
     argslist = [
         "ipr",
@@ -122,12 +134,11 @@ def loaded_reports(tmp_path_factory) -> Dict:
     loaded_report = ipr_conn.get(uri=f"reports?searchText={patient_id}")
     async_loaded_report = ipr_conn.get(uri=f"reports?searchText={async_patient_id}")
 
-    loaded_reports = {
+    loaded_reports_result = {
         "sync": (patient_id, loaded_report),
         "async": (async_patient_id, async_loaded_report),
     }
-    yield loaded_reports
-
+    yield loaded_reports_result
     ipr_conn.delete(uri=f"reports/{loaded_report['reports'][0]['ident']}")
     ipr_conn.delete(uri=f"reports/{async_loaded_report['reports'][0]['ident']}")
 
@@ -154,8 +165,13 @@ def compare_sections(section1, section2):
                         item[subitem].pop(key, None)
                     if isinstance(item[subitem], list):
                         [subsubitem.pop(key, None) for subsubitem in item[subitem]]
+    if isinstance(section1, list):
+        section2_items = [str(item) for item in section2]
+        section2_items.sort()
+        section1_items = [str(item) for item in section1]
+        section1_items.sort()
+        return str(section2_items) == str(section1_items)
     return str(section1) == str(section2)
-
 
 @pytest.mark.skipif(
     not INCLUDE_UPLOAD_TESTS, reason="excluding tests of upload to live ipr instance"

--- a/tests/test_ipr/test_upload.py
+++ b/tests/test_ipr/test_upload.py
@@ -29,6 +29,7 @@ def get_test_spec():
 def get_test_file(name: str) -> str:
     return os.path.join(os.path.dirname(__file__), "test_data", name)
 
+
 @pytest.fixture(scope="module")
 def loaded_reports(tmp_path_factory) -> Dict:
     json_file = tmp_path_factory.mktemp("inputs") / "content.json"
@@ -172,6 +173,7 @@ def compare_sections(section1, section2):
         section1_items.sort()
         return str(section2_items) == str(section1_items)
     return str(section1) == str(section2)
+
 
 @pytest.mark.skipif(
     not INCLUDE_UPLOAD_TESTS, reason="excluding tests of upload to live ipr instance"


### PR DESCRIPTION
Fixes problem occasionally affecting test_upload test results where list elements might appear in a non-matching order