### PR TITLE
SDEV-4431 - bugfix - content.spec.json not in distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ dev =
     mypy
 
 [options.package_data]
-pori_python.ipr = pori/ipr/content.spec.json, py.typed
+pori_python.ipr = pori_python/ipr/content.spec.json, py.typed
 pori_python.graphkb = py.typed
 
 [options.entry_points]


### PR DESCRIPTION
I believe this is just from a typo in the setup.cfg