### PR TITLE
SDEV-4605 - remove input validation pattern check on chromosomeBand -…

### DIFF
--- a/pori_python/ipr/content.spec.json
+++ b/pori_python/ipr/content.spec.json
@@ -99,7 +99,7 @@
             "items": {
                 "properties": {
                     "chromosomeBand": {
-                        "example": "p12.2",
+                        "example": "Xp12.2",
                         "type": "string"
                     },
                     "cna": {

--- a/pori_python/ipr/content.spec.json
+++ b/pori_python/ipr/content.spec.json
@@ -99,8 +99,7 @@
             "items": {
                 "properties": {
                     "chromosomeBand": {
-                        "example": "X:p12.2",
-                        "pattern": "^(\\S+:\\S+?)?$",
+                        "example": "p12.2",
                         "type": "string"
                     },
                     "cna": {

--- a/pori_python/ipr/content.spec.json
+++ b/pori_python/ipr/content.spec.json
@@ -103,7 +103,7 @@
                         "type": "string"
                     },
                     "cna": {
-                        "description": "The copy number alteration (CNA) ratio",
+                        "description": "Copy Number, Absolute (cna)",
                         "example": 1.22,
                         "type": [
                             "number",


### PR DESCRIPTION
… check for colon is non-standard.


Just remove the check for chromosomeband format.  It is only used as a comment anyway.