### PR TITLE
Feat/devsu 2494 add custom text to analysis summary

### DIFF
--- a/pori_python/ipr/main.py
+++ b/pori_python/ipr/main.py
@@ -37,7 +37,7 @@ from .ipr import (
     germline_kb_matches,
     select_expression_plots,
 )
-from .summary import auto_analyst_comments
+from .summary import auto_analyst_comments, ipr_analyst_comments
 from .therapeutic_options import create_therapeutic_options
 from .util import LOG_LEVELS, logger, trim_empty_values
 
@@ -194,6 +194,7 @@ def clean_unsupported_content(upload_content: Dict, ipr_spec: Dict = {}) -> Dict
         "copyVariants",
         "structuralVariants",
         "probeResults",
+        "signatureVariants",
         "msi",
     ]
     for variant_list_section in VARIANT_LIST_KEYS:
@@ -446,12 +447,20 @@ def ipr_report(
         targets = []
 
     logger.info("generating analyst comments")
+
     if generate_comments:
-        comments = {
-            "comments": auto_analyst_comments(
+        graphkb_comments = auto_analyst_comments(
                 graphkb_conn, gkb_matches, disease_name=kb_disease_match, variants=all_variants
             )
-        }
+
+        ipr_comments = ipr_analyst_comments(
+                ipr_conn,
+                gkb_matches,
+                disease_name=kb_disease_match,
+                project_name=content['project'],
+                report_type=content['template']
+            )
+        comments = {"comments": "\n".join([ipr_comments, graphkb_comments])}
     else:
         comments = {"comments": ""}
 

--- a/pori_python/ipr/main.py
+++ b/pori_python/ipr/main.py
@@ -450,16 +450,16 @@ def ipr_report(
 
     if generate_comments:
         graphkb_comments = auto_analyst_comments(
-                graphkb_conn, gkb_matches, disease_name=kb_disease_match, variants=all_variants
-            )
+            graphkb_conn, gkb_matches, disease_name=kb_disease_match, variants=all_variants
+        )
 
         ipr_comments = ipr_analyst_comments(
-                ipr_conn,
-                gkb_matches,
-                disease_name=kb_disease_match,
-                project_name=content['project'],
-                report_type=content['template']
-            )
+            ipr_conn,
+            gkb_matches,
+            disease_name=kb_disease_match,
+            project_name=content['project'],
+            report_type=content['template'],
+        )
         comments = {"comments": "\n".join([ipr_comments, graphkb_comments])}
     else:
         comments = {"comments": ""}

--- a/pori_python/ipr/summary.py
+++ b/pori_python/ipr/summary.py
@@ -428,10 +428,6 @@ def get_ipr_analyst_comments(
         itemlist: list[dict] = []
         itemlist = ipr_conn.get("variant-text", data=data)  # type: ignore
         if itemlist:
-            import pdb
-
-            pdb.set_trace()
-
             project_matches = [
                 item
                 for item in itemlist

--- a/pori_python/ipr/summary.py
+++ b/pori_python/ipr/summary.py
@@ -342,6 +342,40 @@ def section_statements_by_genes(
     return genes
 
 
+def ipr_analyst_comments(
+    ipr_conn: IprConnection,
+    matches: Sequence[KbMatch] | Sequence[Hashabledict],
+    disease_name: str,
+    project_name: str,
+    report_type: str
+):
+    output: List[str] = [
+        "<h3>The comments below were automatically drawn from curated text stored in IPR for variant matches in this report, and have not been manually reviewed</h3>"
+    ]
+
+    items = []
+
+    templates = ipr_conn.get(f'templates?name={report_type}')
+    # if this is genomic expect two results - one 'pharmacogenomic'
+    template_ident = [item for item in templates if item['name']==report_type][0]['ident']
+
+    projects = ipr_conn.get(f'project')
+    project_ident = [item for item in projects if item['name']==project_name][0]['ident']
+
+    match_set = list(set([item['kbVariant'] for item in matches]))
+
+    for variant in match_set:
+        itemlist = ipr_conn.get('variant-text', data={
+            'variantName': variant,
+            'template': template_ident,
+            'project': project_ident
+        })
+        if itemlist:
+            for item in itemlist:
+                output.append(item['text'])
+    return "\n".join(output)
+
+
 def auto_analyst_comments(
     graphkb_conn: GraphKBConnection,
     matches: Sequence[KbMatch] | Sequence[Hashabledict],

--- a/tests/test_ipr/test_main.py
+++ b/tests/test_ipr/test_main.py
@@ -48,24 +48,22 @@ def report_upload_content(tmp_path_factory) -> Dict:
                 "patientId": "PATIENT001",
                 "project": "TEST",
                 "expressionVariants": json.loads(
-                    pd.read_csv(
-                        get_test_file("expression.short.tab"), sep="\t"
-                    ).to_json(orient="records")
-                ),
-                "smallMutations": json.loads(
-                    pd.read_csv(
-                        get_test_file("small_mutations.short.tab"), sep="\t"
-                    ).to_json(orient="records")
-                ),
-                "copyVariants": json.loads(
-                    pd.read_csv(
-                        get_test_file("copy_variants.short.tab"), sep="\t"
-                    ).to_json(orient="records")
-                ),
-                "structuralVariants": json.loads(
-                    pd.read_csv(get_test_file("fusions.tab"), sep="\t").to_json(
+                    pd.read_csv(get_test_file("expression.short.tab"), sep="\t").to_json(
                         orient="records"
                     )
+                ),
+                "smallMutations": json.loads(
+                    pd.read_csv(get_test_file("small_mutations.short.tab"), sep="\t").to_json(
+                        orient="records"
+                    )
+                ),
+                "copyVariants": json.loads(
+                    pd.read_csv(get_test_file("copy_variants.short.tab"), sep="\t").to_json(
+                        orient="records"
+                    )
+                ),
+                "structuralVariants": json.loads(
+                    pd.read_csv(get_test_file("fusions.tab"), sep="\t").to_json(orient="records")
                 ),
                 "kbDiseaseMatch": "colorectal cancer",
             },
@@ -105,9 +103,7 @@ def report_upload_content(tmp_path_factory) -> Dict:
     ):
         with patch.object(IprConnection, "upload_report", new=mock):
             with patch.object(IprConnection, "get_spec", return_value=get_test_spec()):
-                with patch.object(
-                    IprConnection, "get", side_effect=side_effect_function
-                ):
+                with patch.object(IprConnection, "get", side_effect=side_effect_function):
                     command_interface()
 
     assert mock.called
@@ -116,9 +112,7 @@ def report_upload_content(tmp_path_factory) -> Dict:
     return report_content
 
 
-@pytest.mark.skipif(
-    EXCLUDE_INTEGRATION_TESTS, reason="excluding long running integration tests"
-)
+@pytest.mark.skipif(EXCLUDE_INTEGRATION_TESTS, reason="excluding long running integration tests")
 class TestCreateReport:
     def test_main_sections_present(self, report_upload_content: Dict) -> None:
         sections = set(report_upload_content.keys())
@@ -134,10 +128,7 @@ class TestCreateReport:
             assert section in sections
 
     def test_kept_low_quality_fusion(self, report_upload_content: Dict) -> None:
-        fusions = [
-            (sv["gene1"], sv["gene2"])
-            for sv in report_upload_content["structuralVariants"]
-        ]
+        fusions = [(sv["gene1"], sv["gene2"]) for sv in report_upload_content["structuralVariants"]]
         if (
             EXCLUDE_BCGSC_TESTS
         ):  # may be missing statements assoc with SUZ12 if no access to bcgsc data
@@ -154,17 +145,13 @@ class TestCreateReport:
         # eg, A1BG
         assert any([g.get("knownFusionPartner", False) for g in genes])
 
-    @pytest.mark.skipif(
-        EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data"
-    )
+    @pytest.mark.skipif(EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data")
     def test_found_oncogene(self, report_upload_content: Dict) -> None:
         genes = report_upload_content["genes"]
         # eg, ZBTB20
         assert any([g.get("oncogene", False) for g in genes])
 
-    @pytest.mark.skipif(
-        EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data)"
-    )
+    @pytest.mark.skipif(EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data)")
     def test_found_tumour_supressor(self, report_upload_content: Dict) -> None:
         genes = report_upload_content["genes"]
         # eg, ZNRF3
@@ -174,11 +161,7 @@ class TestCreateReport:
         genes = report_upload_content["genes"]
         assert any([g.get("kbStatementRelated", False) for g in genes])
 
-    @pytest.mark.skipif(
-        EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data"
-    )
-    def test_found_cancer_gene_list_match_gene(
-        self, report_upload_content: Dict
-    ) -> None:
+    @pytest.mark.skipif(EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data")
+    def test_found_cancer_gene_list_match_gene(self, report_upload_content: Dict) -> None:
         genes = report_upload_content["genes"]
         assert any([g.get("cancerGeneListMatch", False) for g in genes])

--- a/tests/test_ipr/test_main.py
+++ b/tests/test_ipr/test_main.py
@@ -48,28 +48,39 @@ def report_upload_content(tmp_path_factory) -> Dict:
                 "patientId": "PATIENT001",
                 "project": "TEST",
                 "expressionVariants": json.loads(
-                    pd.read_csv(get_test_file("expression.short.tab"), sep="\t").to_json(
-                        orient="records"
-                    )
+                    pd.read_csv(
+                        get_test_file("expression.short.tab"), sep="\t"
+                    ).to_json(orient="records")
                 ),
                 "smallMutations": json.loads(
-                    pd.read_csv(get_test_file("small_mutations.short.tab"), sep="\t").to_json(
-                        orient="records"
-                    )
+                    pd.read_csv(
+                        get_test_file("small_mutations.short.tab"), sep="\t"
+                    ).to_json(orient="records")
                 ),
                 "copyVariants": json.loads(
-                    pd.read_csv(get_test_file("copy_variants.short.tab"), sep="\t").to_json(
-                        orient="records"
-                    )
+                    pd.read_csv(
+                        get_test_file("copy_variants.short.tab"), sep="\t"
+                    ).to_json(orient="records")
                 ),
                 "structuralVariants": json.loads(
-                    pd.read_csv(get_test_file("fusions.tab"), sep="\t").to_json(orient="records")
+                    pd.read_csv(get_test_file("fusions.tab"), sep="\t").to_json(
+                        orient="records"
+                    )
                 ),
                 "kbDiseaseMatch": "colorectal cancer",
             },
             allow_nan=False,
         )
     )
+
+    def side_effect_function(*args, **kwargs):
+        if 'templates' in args[0]:
+            return [{"name": "genomic", "ident": "001"}]
+        elif args[0] == "project":
+            return [{"name": "TEST", "ident": "001"}]
+        else:
+            return []
+
     with patch.object(
         sys,
         "argv",
@@ -94,7 +105,9 @@ def report_upload_content(tmp_path_factory) -> Dict:
     ):
         with patch.object(IprConnection, "upload_report", new=mock):
             with patch.object(IprConnection, "get_spec", return_value=get_test_spec()):
-                with patch.object(IprConnection, "get", return_value=[]):
+                with patch.object(
+                    IprConnection, "get", side_effect=side_effect_function
+                ):
                     command_interface()
 
     assert mock.called
@@ -103,7 +116,9 @@ def report_upload_content(tmp_path_factory) -> Dict:
     return report_content
 
 
-@pytest.mark.skipif(EXCLUDE_INTEGRATION_TESTS, reason="excluding long running integration tests")
+@pytest.mark.skipif(
+    EXCLUDE_INTEGRATION_TESTS, reason="excluding long running integration tests"
+)
 class TestCreateReport:
     def test_main_sections_present(self, report_upload_content: Dict) -> None:
         sections = set(report_upload_content.keys())
@@ -119,7 +134,10 @@ class TestCreateReport:
             assert section in sections
 
     def test_kept_low_quality_fusion(self, report_upload_content: Dict) -> None:
-        fusions = [(sv["gene1"], sv["gene2"]) for sv in report_upload_content["structuralVariants"]]
+        fusions = [
+            (sv["gene1"], sv["gene2"])
+            for sv in report_upload_content["structuralVariants"]
+        ]
         if (
             EXCLUDE_BCGSC_TESTS
         ):  # may be missing statements assoc with SUZ12 if no access to bcgsc data
@@ -136,13 +154,17 @@ class TestCreateReport:
         # eg, A1BG
         assert any([g.get("knownFusionPartner", False) for g in genes])
 
-    @pytest.mark.skipif(EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data")
+    @pytest.mark.skipif(
+        EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data"
+    )
     def test_found_oncogene(self, report_upload_content: Dict) -> None:
         genes = report_upload_content["genes"]
         # eg, ZBTB20
         assert any([g.get("oncogene", False) for g in genes])
 
-    @pytest.mark.skipif(EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data)")
+    @pytest.mark.skipif(
+        EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data)"
+    )
     def test_found_tumour_supressor(self, report_upload_content: Dict) -> None:
         genes = report_upload_content["genes"]
         # eg, ZNRF3
@@ -152,7 +174,11 @@ class TestCreateReport:
         genes = report_upload_content["genes"]
         assert any([g.get("kbStatementRelated", False) for g in genes])
 
-    @pytest.mark.skipif(EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data")
-    def test_found_cancer_gene_list_match_gene(self, report_upload_content: Dict) -> None:
+    @pytest.mark.skipif(
+        EXCLUDE_ONCOKB_TESTS, reason="excluding tests that depend on oncokb data"
+    )
+    def test_found_cancer_gene_list_match_gene(
+        self, report_upload_content: Dict
+    ) -> None:
         genes = report_upload_content["genes"]
         assert any([g.get("cancerGeneListMatch", False) for g in genes])

--- a/tests/test_ipr/test_main.py
+++ b/tests/test_ipr/test_main.py
@@ -40,7 +40,10 @@ def report_upload_content(tmp_path_factory) -> Dict:
                     {"analysisRole": "expression (disease)", "name": "1"},
                     {"analysisRole": "expression (primary site)", "name": "2"},
                     {"analysisRole": "expression (biopsy site)", "name": "3"},
-                    {"analysisRole": "expression (internal pancancer cohort)", "name": "4"},
+                    {
+                        "analysisRole": "expression (internal pancancer cohort)",
+                        "name": "4",
+                    },
                 ],
                 "patientId": "PATIENT001",
                 "project": "TEST",
@@ -91,7 +94,8 @@ def report_upload_content(tmp_path_factory) -> Dict:
     ):
         with patch.object(IprConnection, "upload_report", new=mock):
             with patch.object(IprConnection, "get_spec", return_value=get_test_spec()):
-                command_interface()
+                with patch.object(IprConnection, "get", return_value=[]):
+                    command_interface()
 
     assert mock.called
 

--- a/tests/test_ipr/test_probe.py
+++ b/tests/test_ipr/test_probe.py
@@ -5,8 +5,8 @@ from typing import Dict
 from unittest.mock import MagicMock, patch
 
 from pori_python.ipr.connection import IprConnection
+from pori_python.ipr import main
 from pori_python.ipr.main import create_report
-
 from .constants import EXCLUDE_INTEGRATION_TESTS
 
 EXCLUDE_BCGSC_TESTS = os.environ.get("EXCLUDE_BCGSC_TESTS") == "1"
@@ -21,29 +21,30 @@ def probe_upload_content() -> Dict:
     mock = MagicMock()
     with patch.object(IprConnection, "upload_report", new=mock):
         with patch.object(IprConnection, "get_spec", return_value={}):
-            create_report(
-                content={
-                    "patientId": "PATIENT001",
-                    "project": "TEST",
-                    "smallMutations": pd.read_csv(
-                        get_test_file("small_mutations_probe.tab"),
-                        sep="\t",
-                        dtype={"chromosome": "string"},
-                    ).to_dict("records"),
-                    "structuralVariants": pd.read_csv(
-                        get_test_file("fusions.tab"), sep="\t"
-                    ).to_dict("records"),
-                    "blargh": "some fake content",
-                    "kbDiseaseMatch": "colorectal cancer",
-                },
-                username=os.environ["IPR_USER"],
-                password=os.environ["IPR_PASS"],
-                log_level="info",
-                ipr_url="http://fake.url.ca",
-                graphkb_username=os.environ.get("GRAPHKB_USER", os.environ["IPR_USER"]),
-                graphkb_password=os.environ.get("GRAPHKB_PASS", os.environ["IPR_PASS"]),
-                graphkb_url=os.environ.get("GRAPHKB_URL", False),
-            )
+            with patch.object(IprConnection, "get", return_value=[]):
+                create_report(
+                    content={
+                        "patientId": "PATIENT001",
+                        "project": "TEST",
+                        "smallMutations": pd.read_csv(
+                            get_test_file("small_mutations_probe.tab"),
+                            sep="\t",
+                            dtype={"chromosome": "string"},
+                        ).to_dict("records"),
+                        "structuralVariants": pd.read_csv(
+                            get_test_file("fusions.tab"), sep="\t"
+                        ).to_dict("records"),
+                        "blargh": "some fake content",
+                        "kbDiseaseMatch": "colorectal cancer",
+                    },
+                    username=os.environ["IPR_USER"],
+                    password=os.environ["IPR_PASS"],
+                    log_level="info",
+                    ipr_url="http://fake.url.ca",
+                    graphkb_username=os.environ.get("GRAPHKB_USER", os.environ["IPR_USER"]),
+                    graphkb_password=os.environ.get("GRAPHKB_PASS", os.environ["IPR_PASS"]),
+                    graphkb_url=os.environ.get("GRAPHKB_URL", False),
+                )
 
     assert mock.called
 

--- a/tests/test_ipr/test_probe.py
+++ b/tests/test_ipr/test_probe.py
@@ -50,12 +50,8 @@ def probe_upload_content() -> Dict:
                     password=os.environ["IPR_PASS"],
                     log_level="info",
                     ipr_url="http://fake.url.ca",
-                    graphkb_username=os.environ.get(
-                        "GRAPHKB_USER", os.environ["IPR_USER"]
-                    ),
-                    graphkb_password=os.environ.get(
-                        "GRAPHKB_PASS", os.environ["IPR_PASS"]
-                    ),
+                    graphkb_username=os.environ.get("GRAPHKB_USER", os.environ["IPR_USER"]),
+                    graphkb_password=os.environ.get("GRAPHKB_PASS", os.environ["IPR_PASS"]),
                     graphkb_url=os.environ.get("GRAPHKB_URL", False),
                 )
 
@@ -65,9 +61,7 @@ def probe_upload_content() -> Dict:
     return report_content
 
 
-@pytest.mark.skipif(
-    EXCLUDE_INTEGRATION_TESTS, reason="excluding long running integration tests"
-)
+@pytest.mark.skipif(EXCLUDE_INTEGRATION_TESTS, reason="excluding long running integration tests")
 class TestCreateReport:
     def test_found_probe_small_mutations(self, probe_upload_content: Dict) -> None:
         assert probe_upload_content["smallMutations"]
@@ -75,9 +69,7 @@ class TestCreateReport:
     @pytest.mark.skipif(
         EXCLUDE_BCGSC_TESTS, reason="excluding tests that depend on BCGSC-specific data"
     )
-    def test_found_probe_small_mutations_match(
-        self, probe_upload_content: Dict
-    ) -> None:
+    def test_found_probe_small_mutations_match(self, probe_upload_content: Dict) -> None:
         # verify each probe had a KB match
         for sm_probe in probe_upload_content["smallMutations"]:
             match_list = [

--- a/tests/test_ipr/test_summary.py
+++ b/tests/test_ipr/test_summary.py
@@ -1,9 +1,11 @@
 from unittest.mock import MagicMock
+from copy import copy
 
 from pori_python.ipr.summary import (
     GRAPHKB_GUI,
     get_preferred_drug_representation,
     substitute_sentence_template,
+    get_ipr_analyst_comments,
 )
 
 
@@ -155,3 +157,199 @@ class TestSubstituteSentenceTemplate:
             sentence
             == f'KRAS increased RNA expression is associated with senitivity to some drug in disease 1, disease 2, and disease 3 (<a href="{GRAPHKB_GUI}/data/table?complex=eyJ0YXJnZXQiOiBbIjYiLCAiNyJdfQ%3D%3D&%40class=Statement" target="_blank" rel="noopener"></a>)'
         )
+
+
+mock_ipr_results = [
+    [
+        {
+            'text': '<p>no cancerType</p>',
+            'variantName': 'ERBB2 amplification',
+            'cancerType': [],
+            'template': {'name': 'test3'},
+            'project': {'name': 'test2'},
+        },
+        {
+            'text': '<p>normal</p>',
+            'variantName': 'ERBB2 amplification',
+            'cancerType': ['test1', 'test'],
+            'template': {'name': 'test3'},
+            'project': {'name': 'test2'},
+        },
+        {
+            'text': '<p>no project</p>',
+            'variantName': 'ERBB2 amplification',
+            'cancerType': ['test1', 'test'],
+            'template': {'name': 'test3'},
+        },
+        {
+            'text': '<p>no template</p>',
+            'variantName': 'ERBB2 amplification',
+            'cancerType': ['test1', 'test'],
+            'project': {'name': 'test2'},
+        },
+    ],
+    [
+        {
+            'text': '<p>normal, second variant</p>',
+            'variantName': 'second variant',
+            'cancerType': ['test1', 'test'],
+            'template': {'name': 'test3'},
+            'project': {'name': 'test2'},
+        },
+    ],
+]
+
+no_comments_found_output = 'No comments found in IPR for variants in this report'
+
+
+class TestVariantTextFromIPR:
+    def test_gets_fully_matched_output_when_possible(self):
+        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        matches = [{'kbVariant': 'ERBB2 amplification'}]
+        ipr_summary = get_ipr_analyst_comments(
+            ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=True,
+            include_nonspecific_template=True,
+        )
+        summary_lines = ipr_summary.split('\n')
+        assert summary_lines[1] == '<h2>ERBB2 amplification (test1,test)</h2>'
+        assert summary_lines[2] == '<p><p>normal</p></p>'
+        assert len(summary_lines) == 3
+
+    def test_omits_nonspecific_project_matches_when_specified(self):
+        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        matches = [{'kbVariant': 'ERBB2 amplification'}]
+        ipr_summary = get_ipr_analyst_comments(
+            ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            project_name='notfound',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=True,
+            include_nonspecific_template=True,
+        )
+        assert ipr_summary == no_comments_found_output
+
+    def test_omits_nonspecific_template_matches_when_specified(self):
+        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        matches = [{'kbVariant': 'ERBB2 amplification'}]
+        ipr_summary = get_ipr_analyst_comments(
+            ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            project_name='test2',
+            report_type='notfound',
+            include_nonspecific_project=True,
+            include_nonspecific_disease=True,
+            include_nonspecific_template=False,
+        )
+        assert ipr_summary == no_comments_found_output
+
+    def test_omits_nonspecific_disease_matches_when_specified(self):
+        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        matches = [{'kbVariant': 'ERBB2 amplification'}]
+        ipr_summary = get_ipr_analyst_comments(
+            ipr_conn,
+            matches=matches,
+            disease_name='notfound',
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=True,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=True,
+        )
+        assert ipr_summary == no_comments_found_output
+
+    def test_includes_nonspecific_project_matches_when_specified(self):
+        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        matches = [{'kbVariant': 'ERBB2 amplification'}]
+        ipr_summary = get_ipr_analyst_comments(
+            ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            project_name='notfound',
+            report_type='test3',
+            include_nonspecific_project=True,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=False,
+        )
+        summary_lines = ipr_summary.split('\n')
+        assert summary_lines[2] == '<p><p>no project</p></p>'
+        assert len(summary_lines) == 3
+
+    def test_includes_nonspecific_template_matches_when_specified(self):
+        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        matches = [{'kbVariant': 'ERBB2 amplification'}]
+        ipr_summary = get_ipr_analyst_comments(
+            ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            project_name='test2',
+            report_type='notfound',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=True,
+        )
+        summary_lines = ipr_summary.split('\n')
+        assert summary_lines[2] == '<p><p>no template</p></p>'
+        assert len(summary_lines) == 3
+
+    def test_includes_nonspecific_disease_matches_when_specified(self):
+        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        matches = [{'kbVariant': 'ERBB2 amplification'}]
+        ipr_summary = get_ipr_analyst_comments(
+            ipr_conn,
+            matches=matches,
+            disease_name='notfound',
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=True,
+            include_nonspecific_template=False,
+        )
+        summary_lines = ipr_summary.split('\n')
+        assert summary_lines[1] == '<h2>ERBB2 amplification (no specific cancer types)</h2>'
+        assert summary_lines[2] == '<p><p>no cancerType</p></p>'
+        assert len(summary_lines) == 3
+
+    def test_prepare_section_for_multiple_variants(self):
+        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        # NB this test relies on matches being processed in this order
+        matches = [{'kbVariant': 'ERBB2 amplification'}, {'kbVariant': 'second variant'}]
+        ipr_summary = get_ipr_analyst_comments(
+            ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=False,
+        )
+        summary_lines = ipr_summary.split('\n')
+        assert len(summary_lines) == 5
+        assert (
+            '\n'.join(summary_lines[1:])
+            == '<h2>ERBB2 amplification (test1,test)</h2>\n<p><p>normal</p></p>\n<h2>second variant (test1,test)</h2>\n<p><p>normal, second variant</p></p>'
+        )
+
+    def test_empty_section_when_no_variant_match(self):
+        ipr_conn = MagicMock(get=MagicMock(side_effect=[[], []]))
+        matches = [{'kbVariant': 'notfound1'}, {'kbVariant': 'notfound2'}]
+        ipr_summary = get_ipr_analyst_comments(
+            ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=False,
+        )
+        assert ipr_summary == no_comments_found_output


### PR DESCRIPTION
Adds functionality to get prepared text for kbmatches from variant-texts endpt in IPR, and include it in the analyst summary.