### PR TITLE
revert to previous analystComments format

### DIFF
--- a/pori_python/ipr/main.py
+++ b/pori_python/ipr/main.py
@@ -498,7 +498,7 @@ def ipr_report(
             include_nonspecific_template=include_nonspecific_template,
         )
         comments_list.append(ipr_comments)
-    comments = "\n".join(comments_list)
+    comments = {'comments': "\n".join(comments_list)}
 
     # OUTPUT CONTENT
     # thread safe deep-copy the original content

--- a/tests/test_graphkb/data.py
+++ b/tests/test_graphkb/data.py
@@ -1,8 +1,8 @@
 """_summary_
-    matches:
-        Array of variants (diplayName and type) that MUST be matching, but not restricted to
-    does_not_matches:
-        Array of variants (diplayName and type) that MUST NOT be matching, but not restricted to
+matches:
+    Array of variants (diplayName and type) that MUST be matching, but not restricted to
+does_not_matches:
+    Array of variants (diplayName and type) that MUST NOT be matching, but not restricted to
 """
 
 # Screening structural variant to rule out small events [KBDEV_1056]


### PR DESCRIPTION
Changes format of submitted comments back to dict like {'comments': commentObject} since otherwise upload fails.