### PR TITLE
SDEV-4811 - load tmb_val from genomeTmb if available.

### DIFF
--- a/pori_python/ipr/main.py
+++ b/pori_python/ipr/main.py
@@ -422,6 +422,7 @@ def ipr_report(
             except Exception as err:
                 logger.error(f"genomeTmb parsing failure {content.get('genomeTmb')}: {err}")
 
+        # TODO: clincal mentioned 'high mutation burden' is arbitrary and users may want to upload a TMB_HIGH cutoff or upload categories.
         if tmb_val >= TMB_HIGH:
             logger.warning(
                 f"GERO-296 - tmburMutationBurden high -checking graphkb matches for {TMB_HIGH_CATEGORY}"

--- a/pori_python/ipr/main.py
+++ b/pori_python/ipr/main.py
@@ -393,14 +393,23 @@ def ipr_report(
     # MATCHING TMB
     tmb_variant: IprVariant = {}  # type: ignore
     tmb_matches = []
-    if "tmburMutationBurden" in content.keys():
+
+    if "genomeTmb" in content.keys() or "tmburMutationBurden" in content.keys():
         tmb_val = 0.0
         tmb = {}
-        try:
-            tmb = content.get("tmburMutationBurden", {})
-            tmb_val = tmb["genomeIndelTmb"] + tmb["genomeSnvTmb"]
-        except Exception as err:
-            logger.error(f"tmburMutationBurden parsing failure: {err}")
+
+        if "tmburMutationBurden" in content.keys():
+            try:
+                tmb = content.get("tmburMutationBurden", {})
+                tmb_val = tmb["genomeIndelTmb"] + tmb["genomeSnvTmb"]
+            except Exception as err:
+                logger.error(f"tmburMutationBurden parsing failure: {err}")
+
+        if "genomeTmb" in content.keys():
+            try:
+                tmb_val = float(content.get("genomeTmb"))
+            except Exception as err:
+                logger.error(f"genomeTmb parsing failure {content.get('genomeTmb')}: {err}")
 
         if tmb_val >= TMB_HIGH:
             logger.warning(


### PR DESCRIPTION
https://www.bcgsc.ca/jira/browse/SDEV-4811

For to remove vardb dependence from gsc_report --template rapid ([SDEV-4536](https://www.bcgsc.ca/jira/browse/SDEV-4536)),
pori_python needs updates to match to the genomeTmb value.

For backwards compatibility, genomeTmb should be derived from tmburMutationBurden components like previously.