### PR TITLE
Feat/devsu 2625 add option to not drop test reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note that IPR tests will try to use the BCGSC production GraphKB API by default.
 If you want to test interaction with a different instance, you will need to
 set the GraphKB variables.
 
-Set EXCLUDE vars to 1 if you don't want to run these tests. 
+Set EXCLUDE vars to 1 if you don't want to run these tests.
 ONCOKB and BCGSC tests are enabled by default.
 
 ```bash
@@ -61,17 +61,21 @@ export IPR_URL='http://localhost:8081/api'
 export GRAPHKB_USER='pori_admin'
 export GRAPHKB_PASS='pori_admin'
 export GRAPHKB_URL='http://localhost:8080/api'
-EXCLUDE_BCGSC_TESTS = 1
-EXCLUDE_ONCOKB_TESTS = 1
+export EXCLUDE_BCGSC_TESTS=1
+export EXCLUDE_ONCOKB_TESTS=1
 ```
 
 If you want to run tests that upload reports to a live IPR instance,
 specify the url of the IPR API you want to use and set the test var to 1.
 These tests are disabled by default.
 
+The created reports are deleted by default. If you want to keep them,
+set DELETE_UPLOAD_TEST_REPORTS to 0 in the env.
+
 ```bash
 export IPR_TEST_URL='http://localhost:8081/api'
-INCLUDE_UPLOAD_TESTS = 1
+export INCLUDE_UPLOAD_TESTS=1
+export DELETE_UPLOAD_TEST_REPORTS=0
 ```
 
 ```bash

--- a/tests/test_ipr/test_upload.py
+++ b/tests/test_ipr/test_upload.py
@@ -16,6 +16,7 @@ from .constants import EXCLUDE_INTEGRATION_TESTS
 EXCLUDE_BCGSC_TESTS = os.environ.get("EXCLUDE_BCGSC_TESTS") == "1"
 EXCLUDE_ONCOKB_TESTS = os.environ.get("EXCLUDE_ONCOKB_TESTS") == "1"
 INCLUDE_UPLOAD_TESTS = os.environ.get("INCLUDE_UPLOAD_TESTS", 0) == "1"
+DELETE_UPLOAD_TEST_REPORTS = os.environ.get("DELETE_UPLOAD_TEST_REPORTS", 1) == "1"
 
 
 def get_test_spec():
@@ -154,9 +155,9 @@ def loaded_reports(tmp_path_factory) -> Generator:
         "async": (async_patient_id, async_loaded_report),
     }
     yield loaded_reports_result
-    return
-    ipr_conn.delete(uri=f"reports/{loaded_report['reports'][0]['ident']}")
-    ipr_conn.delete(uri=f"reports/{async_loaded_report['reports'][0]['ident']}")
+    if DELETE_UPLOAD_TEST_REPORTS:
+        ipr_conn.delete(uri=f"reports/{loaded_report['reports'][0]['ident']}")
+        ipr_conn.delete(uri=f"reports/{async_loaded_report['reports'][0]['ident']}")
 
 
 def get_section(loaded_report, section_name):

--- a/tests/test_ipr/test_upload.py
+++ b/tests/test_ipr/test_upload.py
@@ -15,8 +15,8 @@ from .constants import EXCLUDE_INTEGRATION_TESTS
 
 EXCLUDE_BCGSC_TESTS = os.environ.get("EXCLUDE_BCGSC_TESTS") == "1"
 EXCLUDE_ONCOKB_TESTS = os.environ.get("EXCLUDE_ONCOKB_TESTS") == "1"
-INCLUDE_UPLOAD_TESTS = os.environ.get("INCLUDE_UPLOAD_TESTS", 0) == "1"
-DELETE_UPLOAD_TEST_REPORTS = os.environ.get("DELETE_UPLOAD_TEST_REPORTS", 1) == "1"
+INCLUDE_UPLOAD_TESTS = os.environ.get("INCLUDE_UPLOAD_TESTS", "0") == "1"
+DELETE_UPLOAD_TEST_REPORTS = os.environ.get("DELETE_UPLOAD_TEST_REPORTS", "1") == "1"
 
 
 def get_test_spec():


### PR DESCRIPTION
Adds option to not drop test reports generated by the test_upload test set.