### PR TITLE
allows dict values for cosmic inputs

### DIFF
--- a/pori_python/ipr/inputs.py
+++ b/pori_python/ipr/inputs.py
@@ -446,6 +446,7 @@ def preprocess_cosmic(rows: Iterable[Dict]) -> Iterable[Dict]:
     Process cosmic inputs into preformatted signature inputs
     Note: Cosmic and dMMR already evaluated against thresholds in gsc_report
     """
+
     def get_sig(sig):
         return sig if isinstance(sig, str) else sig['signature']
 

--- a/pori_python/ipr/inputs.py
+++ b/pori_python/ipr/inputs.py
@@ -446,10 +446,13 @@ def preprocess_cosmic(rows: Iterable[Dict]) -> Iterable[Dict]:
     Process cosmic inputs into preformatted signature inputs
     Note: Cosmic and dMMR already evaluated against thresholds in gsc_report
     """
+    def get_sig(sig):
+        return sig if isinstance(sig, str) else sig['signature']
+
     return [
         {
-            "displayName": f"{signature} {COSMIC_SIGNATURE_VARIANT_TYPE}",
-            "signatureName": signature,
+            "displayName": f"{get_sig(signature)} {COSMIC_SIGNATURE_VARIANT_TYPE}",
+            "signatureName": get_sig(signature),
             "variantTypeName": COSMIC_SIGNATURE_VARIANT_TYPE,
         }
         for signature in rows


### PR DESCRIPTION
Currently the cosmic variant preprocessor expects a list of str but it's not getting this from the test_upload.py suite and seems like it might not be reasonable to expect this in future. This update lets users submit a dict similar to how other signatures are handled.