### PR TITLE
Feature/kbdev 1306 fix disease matching

### DIFF
--- a/pori_python/ipr/ipr.py
+++ b/pori_python/ipr/ipr.py
@@ -686,7 +686,7 @@ def get_kb_disease_matches(
 
     if not similarToExtended:
         if verbose:
-            logger.info("Matching disease ({kb_disease_match}) to graphkb using get_term_tree()")
+            logger.info(f"Matching disease ({kb_disease_match}) to graphkb using get_term_tree()")
         # Previous solution w/ get_term_tree() -> 'similarTo' queryType
         disease_matches = list(
             {

--- a/pori_python/ipr/ipr.py
+++ b/pori_python/ipr/ipr.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 from itertools import product
 from copy import copy
 from typing import Dict, Iterable, List, Sequence, Set, Tuple, cast
+from requests.exceptions import HTTPError
 import uuid
+
 from pori_python.graphkb import GraphKBConnection
 from pori_python.graphkb import statement as gkb_statement
 from pori_python.graphkb import vocab as gkb_vocab
@@ -664,7 +666,10 @@ def get_kb_disease_matches(
                     "returnProperties": ["@rid"]
                 })
             })
-    except:
+    except HTTPError:
+        if verbose:
+            logger.info(f"Failed at using 'similarToExtended' queryType. Trying again with get_term_tree()")
+
         # Previous solution w/ get_term_tree() -> 'similarTo' queryType
         disease_matches = list({
             r["@rid"]

--- a/pori_python/ipr/ipr.py
+++ b/pori_python/ipr/ipr.py
@@ -10,7 +10,7 @@ from requests.exceptions import HTTPError
 import uuid
 from copy import copy
 from itertools import product
-from typing import Dict, Iterable, List, Sequence, Set, Tuple, cast
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple, cast
 
 from pori_python.graphkb import GraphKBConnection
 from pori_python.graphkb import statement as gkb_statement
@@ -633,7 +633,7 @@ def get_kb_matches_sections(
 
 def get_kb_disease_matches(
     graphkb_conn: GraphKBConnection,
-    kb_disease_match: str = None,
+    kb_disease_match: Optional[str] = None,
     verbose: bool = True,
     similarToExtended: bool = True,
 ) -> list[str]:

--- a/pori_python/ipr/ipr.py
+++ b/pori_python/ipr/ipr.py
@@ -641,7 +641,9 @@ def get_kb_disease_matches(
             logger.warning(f"No disease provided; will use '{kb_disease_match}'")
 
     if verbose:
-        logger.info(f"Matching disease ({kb_disease_match}) to graphkb")
+        logger.info(
+            f"Matching disease ({kb_disease_match}) to graphkb using 'similarToExtended' queryType."
+        )
 
     disease_matches = []
     try:

--- a/tests/test_ipr/test_ipr.py
+++ b/tests/test_ipr/test_ipr.py
@@ -175,9 +175,7 @@ KB_MATCHES_STATEMENTS = [
 def graphkb_conn():
     # Mock for the 'query' method
     query_mock = Mock()
-    query_return_values = [
-        [{"@rid": v} for v in APPROVED_EVIDENCE_RIDS]
-    ]
+    query_return_values = [[{"@rid": v} for v in APPROVED_EVIDENCE_RIDS]]
     query_index = {"value": -1}  # Mutable index for closure
 
     def query_side_effect(*args, **kwargs):
@@ -277,9 +275,9 @@ class TestGetKbDiseaseMatches:
 
     def test_get_kb_disease_matches_default(self, graphkb_conn) -> None:
         get_kb_disease_matches(graphkb_conn)
-        assert graphkb_conn.query.call_args_list[0].args == ({
-            'target': 'Disease', 'filters': {'name': 'cancer'}
-        },)
+        assert graphkb_conn.query.call_args_list[0].args == (
+            {'target': 'Disease', 'filters': {'name': 'cancer'}},
+        )
 
 
 class TestConvertStatementsToAlterations:


### PR DESCRIPTION
Use 'similarToExtended' queryType for Disease matching instead of get_term_tree().
Fallback to former matching method if 'similarToExtended' queryType is not implemented on a given GraphKB API.
In both cases a logger message display which matching method has been used.