### PR TITLE
feat/DEVSU-2786 get nct instead of pmid for trials

### DIFF
--- a/pori_python/ipr/ipr.py
+++ b/pori_python/ipr/ipr.py
@@ -167,7 +167,9 @@ def convert_statements_to_alterations(
         ]
         diseases = [c for c in statement["conditions"] if c["@class"] == "Disease"]
         disease_match = len(diseases) == 1 and diseases[0]["@rid"] in disease_matches
-        pmid = ";".join([e["displayName"] for e in statement["evidence"]])
+        reference = ";".join([e["displayName"] for e in statement["evidence"]])
+        if statement['relevance']['name'] == 'eligibility':
+            reference = ";".join([e["sourceId"] for e in statement["evidence"]])
 
         ipr_section = gkb_statement.categorize_relevance(
             graphkb_conn, statement["relevance"]["@rid"]
@@ -207,7 +209,7 @@ def convert_statements_to_alterations(
                     "variantType": "",
                     "kbVariantId": variant["@rid"],
                     "matchedCancer": disease_match,
-                    "reference": pmid,
+                    "reference": reference,
                     "relevance": statement["relevance"]["displayName"],
                     "kbRelevanceId": statement["relevance"]["@rid"],
                     "externalSource": (

--- a/tests/test_ipr/test_ipr.py
+++ b/tests/test_ipr/test_ipr.py
@@ -186,10 +186,7 @@ def base_graphkb_statement(disease_id: str = "disease", relevance_rid: str = "ot
                     "displayName": "KRAS increased expression",
                 },
             ],
-            "evidence": [{
-                "displayName": "pmid12345",
-                "sourceId": "nct12345"
-            }],
+            "evidence": [{"displayName": "pmid12345", "sourceId": "nct12345"}],
             "subject": {
                 "@class": "dummy_value",
                 "@rid": "101:010",

--- a/tests/test_ipr/test_ipr.py
+++ b/tests/test_ipr/test_ipr.py
@@ -186,7 +186,10 @@ def base_graphkb_statement(disease_id: str = "disease", relevance_rid: str = "ot
                     "displayName": "KRAS increased expression",
                 },
             ],
-            "evidence": [],
+            "evidence": [{
+                "displayName": "pmid12345",
+                "sourceId": "nct12345"
+            }],
             "subject": {
                 "@class": "dummy_value",
                 "@rid": "101:010",
@@ -360,6 +363,27 @@ class TestConvertStatementsToAlterations:
         assert len(result) == 1
         row = result[0]
         assert row["category"] == "diagnostic"
+
+    def test_reference_from_displayname_for_noneligibility_stmts(self, graphkb_conn) -> None:
+        statement = base_graphkb_statement()
+
+        result = convert_statements_to_alterations(
+            graphkb_conn, [statement], DISEASE_RIDS, {"variant_rid"}
+        )
+        assert len(result) == 1
+        row = result[0]
+        assert row["reference"] == "pmid12345"
+
+    def test_reference_from_sourceid_for_eligibility_stmts(self, graphkb_conn) -> None:
+        statement = base_graphkb_statement()
+        statement["relevance"]["name"] = "eligibility"
+
+        result = convert_statements_to_alterations(
+            graphkb_conn, [statement], DISEASE_RIDS, {"variant_rid"}
+        )
+        assert len(result) == 1
+        row = result[0]
+        assert row["reference"] == "nct12345"
 
     @patch("pori_python.ipr.ipr.get_evidencelevel_mapping")
     def test_unapproved_therapeutic(self, mock_get_evidencelevel_mapping, graphkb_conn) -> None:

--- a/tests/test_ipr/test_upload.py
+++ b/tests/test_ipr/test_upload.py
@@ -332,7 +332,7 @@ class TestCreateReport:
             stmts = [item for item in multivariant_stmts if item["kbStatementId"] == stmt_id]
 
             # we expect two stmts, one for each condition set
-            assert len(stmts) == 2
+            assert len(stmts) == 3
 
             # we expect each condition set to have two kb variants in it
             # we expect the two kb variants to be the same in each stmt


### PR DESCRIPTION
Where a kbstatement concerns a trial, provide the nct id to ipr as the 'reference' property instead of leaving the field blank (currently happening where there's no pmid). 