### PR TITLE
exclude partial-only matched kbvars from key alts

### DIFF
--- a/pori_python/ipr/ipr.py
+++ b/pori_python/ipr/ipr.py
@@ -269,7 +269,9 @@ def select_expression_plots(
 
 
 def create_key_alterations(
-    kb_matches: List[Hashabledict], all_variants: Sequence[IprVariant]
+    kb_matches: List[Hashabledict],
+    all_variants: Sequence[IprVariant],
+    included_kb_matches: List[KbVariantMatch],
 ) -> Tuple[List[Dict], Dict]:
     """Create the list of significant variants matched by the KB.
 
@@ -284,7 +286,12 @@ def create_key_alterations(
     }
     counts: Dict[str, Set] = {v: set() for v in type_mapping.values()}
     skipped_variant_types = []
+
+    included_kbvariant_ids = list(set([item['kbVariantId'] for item in included_kb_matches]))
+
     for kb_match in kb_matches:
+        if kb_match['kbVariantId'] not in included_kbvariant_ids:
+            continue
         variant_type = kb_match["variantType"]
         variant_key = kb_match["variant"]
         if kb_match["category"] == "unknown":

--- a/pori_python/ipr/ipr.py
+++ b/pori_python/ipr/ipr.py
@@ -276,6 +276,15 @@ def create_key_alterations(
     """Create the list of significant variants matched by the KB.
 
     This list of matches is also used to create the variant counts.
+
+    kb_matches: the full list of matched kb objects found for the reported variants
+    all_variants: the full list of all reported variants, matched or unmatched
+    included_kb_matches: the list of kb_variant ids to be allowed in the key alterations table;
+        this is all kb_variants if partially matched statements are allowed, or
+        the subset of kb_variants that are conditions for at least one
+        fully satisfied statement condition set, if partially matched statements
+        are not allowed (ie, kb_variants that are not part of any fully satisfied
+        statement condition set are excluded)
     """
     alterations = []
     type_mapping = {

--- a/pori_python/ipr/main.py
+++ b/pori_python/ipr/main.py
@@ -512,8 +512,9 @@ def ipr_report(
     )
 
     # KEY ALTERATIONS
-    # must do after pruning of kbMatches for kb_matched_sections
-    key_alterations, variant_counts = create_key_alterations(gkb_matches, all_variants)
+    key_alterations, variant_counts = create_key_alterations(
+        gkb_matches, all_variants, kb_matched_sections['kbMatches']
+    )
 
     # OUTPUT CONTENT
     # thread safe deep-copy the original content

--- a/tests/test_ipr/test_ipr.py
+++ b/tests/test_ipr/test_ipr.py
@@ -11,6 +11,7 @@ from pori_python.ipr.ipr import (
     get_kb_statement_matched_conditions,
     get_kb_variants,
     get_kb_matches_sections,
+    create_key_alterations,
 )
 from pori_python.types import Statement
 
@@ -484,15 +485,22 @@ GKB_MATCHES = [
         "kbContextId": "#135:8764",
         "kbRelevanceId": "#147:32",
         "kbStatementId": "#155:13511",
-        "requiredKbMatches": ["#159:5426", "#161:938"],
+        "requiredKbMatches": ["#159:54261", "#161:9381"],
         "kbVariant": "BRCA1 mutation",
-        "kbVariantId": "#161:938",
+        "kbVariantId": "#161:9381",
         "matchedCancer": False,
         "reference": "MOAlmanac FDA-56",
         "relevance": "therapy",
         "variantType": "mut",
         "reviewStatus": None,
     },
+]
+
+ALL_VARIANTS = [
+    {"variant": "var1", "key": '1', "variantType": 'mut'},
+    {"variant": "var2", "key": '2', "variantType": 'mut'},
+    {"variant": "var3", "key": '3', "variantType": 'mut'},
+    {"variant": "var4", "key": '4', "variantType": 'mut'},
 ]
 
 BASIC_GKB_MATCH = {
@@ -830,3 +838,21 @@ class TestKbMatchSectionPrep:
         kbcs = get_kb_statement_matched_conditions(gkb_matches, allow_partial_matches=True)
         assert len(stmts) == 2  # X and Y
         assert len(kbcs) == 2
+
+    def test_create_key_alterations_includes_only_pruned_kbmatches(self):
+        gkb_matches = create_gkb_matches(GKB_MATCHES)
+
+        sections1 = get_kb_matches_sections(gkb_matches, allow_partial_matches=False)
+        key_alts1, counts1 = create_key_alterations(
+            gkb_matches, ALL_VARIANTS, sections1['kbMatches']
+        )
+
+        sections2 = get_kb_matches_sections(gkb_matches, allow_partial_matches=True)
+        key_alts2, counts2 = create_key_alterations(
+            gkb_matches, ALL_VARIANTS, sections2['kbMatches']
+        )
+
+        # check partial-match-only variants are not included in key alterations when
+        # partial matches is false
+        assert len(key_alts1) == 3
+        assert len(key_alts2) == 4


### PR DESCRIPTION
When creating the list of key alterations, uses the list of kbvariants prepared in the previous step to exclude alterations that won't appear in the kbmatches section (that is, variants that are not part of a complete match to a kbstatement, if allow_partial_matches is False).