### PR TITLE
fix sigv pto autogeneration

### DIFF
--- a/pori_python/ipr/util.py
+++ b/pori_python/ipr/util.py
@@ -61,6 +61,11 @@ def create_variant_name_tuple(variant: IprVariant) -> Tuple[str, str]:
         return (gene, str(variant.get('expressionState', '')))
     elif variant_type == 'cnv':
         return (gene, str(variant.get('cnvState', '')))
+    elif variant_type == 'sigv':
+        return (
+            variant.get('signatureName', variant.get('displayName')),
+            str(variant.get('variantTypeName', '')),
+        )
     variant_split = (
         variant['variant'].split(':', 1)[1] if ':' in variant['variant'] else variant['variant']
     )

--- a/tests/test_ipr/test_util.py
+++ b/tests/test_ipr/test_util.py
@@ -17,30 +17,32 @@ def test_trim_empty_values(input, output_keys):
     [
         [
             {'variantType': 'exp', 'gene': 'GENE', 'expressionState': 'increased expression'},
-            'increased expression',
+            ('GENE', 'increased expression'),
         ],
-        [{'variantType': 'cnv', 'gene': 'GENE', 'cnvState': 'amplification'}, 'amplification'],
-        [{'variantType': 'other', 'gene2': 'GENE', 'variant': 'GENE:anything'}, 'anything'],
+        [
+            {'variantType': 'cnv', 'gene': 'GENE', 'cnvState': 'amplification'},
+            ('GENE', 'amplification'),
+        ],
+        [
+            {'variantType': 'other', 'gene2': 'GENE', 'variant': 'GENE:anything'},
+            ('GENE', 'anything'),
+        ],
+        [
+            {'variantType': 'sigv', 'displayName': 'test signature signature present'},
+            ('test signature signature present', ''),
+        ],
+        [
+            {
+                'variantType': 'sigv',
+                'displayName': 'test signature signature present',
+                'signatureName': 'test signature',
+                'variantTypeName': 'signature present',
+            },
+            ('test signature', 'signature present'),
+        ],
     ],
 )
 def test_create_variant_name_tuple(variant, result):
     gene, name = create_variant_name_tuple(variant)
-    assert name == result
-    assert gene == 'GENE'
-
-
-def test_create_signature_variant_name_tuple():
-    v1 = {
-        'variantType': 'sigv',
-        'displayName': 'test signature signature present',
-        'signatureName': 'test signature',
-        'variantTypeName': 'signature present',
-    }
-    gene, name = create_variant_name_tuple(v1)
-    assert name == 'signature present'
-    assert gene == 'test signature'
-
-    v2 = {'variantType': 'sigv', 'displayName': 'test signature signature present'}
-    gene, name = create_variant_name_tuple(v2)
-    assert name == ''
-    assert gene == 'test signature signature present'
+    assert gene == result[0]
+    assert name == result[1]

--- a/tests/test_ipr/test_util.py
+++ b/tests/test_ipr/test_util.py
@@ -27,3 +27,20 @@ def test_create_variant_name_tuple(variant, result):
     gene, name = create_variant_name_tuple(variant)
     assert name == result
     assert gene == 'GENE'
+
+
+def test_create_signature_variant_name_tuple():
+    v1 = {
+        'variantType': 'sigv',
+        'displayName': 'test signature signature present',
+        'signatureName': 'test signature',
+        'variantTypeName': 'signature present',
+    }
+    gene, name = create_variant_name_tuple(v1)
+    assert name == 'signature present'
+    assert gene == 'test signature'
+
+    v2 = {'variantType': 'sigv', 'displayName': 'test signature signature present'}
+    gene, name = create_variant_name_tuple(v2)
+    assert name == ''
+    assert gene == 'test signature signature present'


### PR DESCRIPTION
Fixes handling of signature variants in function that creates variant name for potential therapeutic options table.