### PR TITLE
SDEV-5340 - output_json - use json.dump so output is formatted.

### DIFF
--- a/pori_python/ipr/main.py
+++ b/pori_python/ipr/main.py
@@ -654,7 +654,7 @@ def ipr_report(
     if always_write_output_json:
         logger.info(f'Writing IPR upload json to: {output_json_path}')
         with open(output_json_path, 'w') as fh:
-            fh.write(json.dumps(output))
+            json.dump(output, fh, indent=4)
 
     logger.info(f'made {graphkb_conn.request_count} requests to graphkb')
     logger.info(f'average load {int(graphkb_conn.load or 0)} req/s')


### PR DESCRIPTION

Makes the returned json file more formatted, for viewing / grepping:

eg.
```
 341     "project": "MoHCCN_-_AML",                                                                                                                                                                                 347     "kbMatches": [
348         {
349             "kbVariant": "DNMT3A mutation",
350             "variant": "c7f8d62d6f20ebd7f1e0b136252729e0",
351             "variantType": "mut",
352             "kbVariantId": "#163:41"
353         },
```