### PR TITLE
SDEV-5394 - bugfix get_cancer_genes - cancer_genes list should includ…

### DIFF
--- a/pori_python/graphkb/genes.py
+++ b/pori_python/graphkb/genes.py
@@ -88,11 +88,24 @@ def get_cancer_genes(conn: GraphKBConnection) -> List[Ontology]:
         conn: the graphkb connection object
 
     Returns:
-        gene (Feature) records
+        List of gene (Feature) records
     """
-    return _get_tumourigenesis_genes_list(
-        conn, CANCER_GENE, [ONCOKB_SOURCE_NAME, TSO500_SOURCE_NAME]
+
+    def unique_genes(genes: List[Ontology]) -> List[Ontology]:
+        """Use @rid to get unique genes from a list of gene records."""
+        unique = {}
+        for gene in genes:
+            if gene['@rid'] not in unique:
+                unique[gene['@rid']] = gene
+        return list(unique.values())
+
+    gkb_cancer_genes = (
+        _get_tumourigenesis_genes_list(conn, CANCER_GENE, [ONCOKB_SOURCE_NAME, TSO500_SOURCE_NAME])
+        + get_oncokb_tumour_supressors(conn)
+        + get_oncokb_oncogenes(conn)
     )
+
+    return sorted(unique_genes(gkb_cancer_genes), key=lambda g: g['displayName'])
 
 
 def get_therapeutic_associated_genes(graphkb_conn: GraphKBConnection) -> List[Ontology]:

--- a/tests/test_graphkb/test_genes.py
+++ b/tests/test_graphkb/test_genes.py
@@ -142,12 +142,13 @@ def test_tumour_supressors(conn):
 def test_cancer_genes(conn):
     result = get_cancer_genes(conn)
     names = {row['name'] for row in result}
+    # cancer_genes includes oncogenes, tumour suppressors, and cancer gene list genes, so all should be present
     for gene in CANONICAL_CG:
         assert gene in names
     for gene in CANONICAL_TS:
-        assert gene not in names
+        assert gene in names
     for gene in CANONICAL_ONCOGENES:
-        assert gene not in names
+        assert gene in names
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
…e tumour_suppressors and oncogenes.

Update the list returned by the get_cancer_genes function to include all oncogenes and tumour_suppressors.


Based on Erin's comments in:
https://www.bcgsc.ca/jira/browse/SDEV-5394