### PR TITLE
Add GraphKBConnection.version

### DIFF
--- a/pori_python/graphkb/util.py
+++ b/pori_python/graphkb/util.py
@@ -354,6 +354,18 @@ class GraphKBConnection:
             raise AssertionError(f'Unable to unqiuely identify source with name {name}')
         return source[0]
 
+    @property
+    def version(self) -> Dict[str, str]:
+        """
+        Retrieve GraphKB components version
+
+        Returns:
+            Dict[str, str]: component keys with version values
+
+            e.g. > {"api":"3.17.3","db":"production","parser":"2.1.0","schema":"4.1.1"}
+        """
+        return self.request('version')
+
 
 def get_rid(conn: GraphKBConnection, target: str, name: str) -> str:
     """

--- a/tests/test_graphkb/test_util.py
+++ b/tests/test_graphkb/test_util.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import re
 
 from pori_python.graphkb import GraphKBConnection, util
 
@@ -149,3 +150,17 @@ class TestStringifyVariant:
         variant = conn.get_record_by_id(rid)
         if variant and variant.get('createdAt', None) == createdAt:
             assert util.stringifyVariant(variant=variant, **opt) == stringifiedVariant
+
+
+class TestVersion:
+    def test_version(self, conn):
+        version = conn.version
+        assert version['db'] in [
+            'production',
+            'production-sync-dev',
+            'production-sync-staging',
+        ]
+        SEMANTIC_VERSIONING_REGEX = re.compile(r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$')
+        assert SEMANTIC_VERSIONING_REGEX.match(version['api'])
+        assert SEMANTIC_VERSIONING_REGEX.match(version['parser'])
+        assert SEMANTIC_VERSIONING_REGEX.match(version['schema'])


### PR DESCRIPTION
Make it easier for internal and third party apps to get the version of all GraphKB components.