### PR TITLE
DEVSU-3011 Missing Canned Variant Text

### DIFF
--- a/pori_python/ipr/summary.py
+++ b/pori_python/ipr/summary.py
@@ -434,12 +434,12 @@ def get_ipr_analyst_comments(
             project_matches = [
                 item
                 for item in itemlist
-                if 'project' in item.keys() and item['project']['name'] == project_name
+                if 'projects' in item.keys() and project_name in [p['name'] for p in item['projects']]
             ]
             if project_matches:
                 itemlist = project_matches
             elif include_nonspecific_project:
-                itemlist = [item for item in itemlist if 'project' not in item.keys()]
+                itemlist = [item for item in itemlist if 'projects' not in item.keys()]
             else:
                 itemlist = []
 
@@ -463,7 +463,6 @@ def get_ipr_analyst_comments(
                 )
                 > 0
             ]
-
             if disease_matches:
                 itemlist = disease_matches
             elif include_nonspecific_disease:

--- a/pori_python/ipr/summary.py
+++ b/pori_python/ipr/summary.py
@@ -434,7 +434,8 @@ def get_ipr_analyst_comments(
             project_matches = [
                 item
                 for item in itemlist
-                if 'projects' in item.keys() and project_name in [p['name'] for p in item['projects']]
+                if 'projects' in item.keys()
+                and project_name in [p['name'] for p in item['projects']]
             ]
             if project_matches:
                 itemlist = project_matches

--- a/tests/test_ipr/test_summary.py
+++ b/tests/test_ipr/test_summary.py
@@ -166,14 +166,14 @@ mock_ipr_results = [
             'variantName': 'ERBB2 amplification',
             'cancerType': [],
             'template': {'name': 'test3'},
-            'project': {'name': 'test2'},
+            'projects': [{'name': 'test2'}],
         },
         {
             'text': '<p>normal</p>',
             'variantName': 'ERBB2 amplification',
             'cancerType': ['test1', 'test'],
             'template': {'name': 'test3'},
-            'project': {'name': 'test2'},
+            'projects': [{'name': 'test2'}],
         },
         {
             'text': '<p>no project</p>',
@@ -185,7 +185,7 @@ mock_ipr_results = [
             'text': '<p>no template</p>',
             'variantName': 'ERBB2 amplification',
             'cancerType': ['test1', 'test'],
-            'project': {'name': 'test2'},
+            'projects': [{'name': 'test2'}],
         },
     ],
     [
@@ -194,7 +194,7 @@ mock_ipr_results = [
             'variantName': 'second variant',
             'cancerType': ['test1', 'test'],
             'template': {'name': 'test3'},
-            'project': {'name': 'test2'},
+            'projects': [{'name': 'test2'}],
         },
     ],
 ]

--- a/tests/test_ipr/test_summary.py
+++ b/tests/test_ipr/test_summary.py
@@ -1,6 +1,7 @@
 from copy import copy
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from pori_python.ipr.connection import IprConnection
 from pori_python.ipr.summary import (
     GRAPHKB_GUI,
     get_ipr_analyst_comments,
@@ -202,163 +203,207 @@ mock_ipr_results = [
 no_comments_found_output = 'No comments found in IPR for variants in this report'
 
 
+def make_ipr_get_mock(results):
+    """Build a requests.request mock so IprConnection.get() runs for real against fake HTTP responses."""
+    responses = [
+        MagicMock(json=MagicMock(return_value=r), raise_for_status=MagicMock()) for r in results
+    ]
+    return MagicMock(side_effect=responses)
+
+
 class TestVariantTextFromIPR:
     def test_gets_fully_matched_output_when_possible(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='test1',
-            disease_match_names=[],
-            project_name='test2',
-            report_type='test3',
-            include_nonspecific_project=False,
-            include_nonspecific_disease=True,
-            include_nonspecific_template=True,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock(copy(mock_ipr_results)),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='test1',
+                disease_match_names=[],
+                project_name='test2',
+                report_type='test3',
+                include_nonspecific_project=False,
+                include_nonspecific_disease=True,
+                include_nonspecific_template=True,
+            )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[1] == '<h2>ERBB2 amplification (test1,test)</h2>'
         assert summary_lines[2] == '<p><p>normal</p></p>'
         assert len(summary_lines) == 3
 
     def test_omits_nonspecific_project_matches_when_specified(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='test1',
-            disease_match_names=[],
-            project_name='notfound',
-            report_type='test3',
-            include_nonspecific_project=False,
-            include_nonspecific_disease=True,
-            include_nonspecific_template=True,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock(copy(mock_ipr_results)),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='test1',
+                disease_match_names=[],
+                project_name='notfound',
+                report_type='test3',
+                include_nonspecific_project=False,
+                include_nonspecific_disease=True,
+                include_nonspecific_template=True,
+            )
         assert ipr_summary == no_comments_found_output
 
     def test_omits_nonspecific_template_matches_when_specified(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='test1',
-            disease_match_names=[],
-            project_name='test2',
-            report_type='notfound',
-            include_nonspecific_project=True,
-            include_nonspecific_disease=True,
-            include_nonspecific_template=False,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock(copy(mock_ipr_results)),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='test1',
+                disease_match_names=[],
+                project_name='test2',
+                report_type='notfound',
+                include_nonspecific_project=True,
+                include_nonspecific_disease=True,
+                include_nonspecific_template=False,
+            )
         assert ipr_summary == no_comments_found_output
 
     def test_omits_nonspecific_disease_matches_when_specified(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='notfound',
-            disease_match_names=[],
-            project_name='test2',
-            report_type='test3',
-            include_nonspecific_project=True,
-            include_nonspecific_disease=False,
-            include_nonspecific_template=True,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock(copy(mock_ipr_results)),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='notfound',
+                disease_match_names=[],
+                project_name='test2',
+                report_type='test3',
+                include_nonspecific_project=True,
+                include_nonspecific_disease=False,
+                include_nonspecific_template=True,
+            )
         assert ipr_summary == no_comments_found_output
 
     def test_includes_nonspecific_project_matches_when_specified(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='test1',
-            disease_match_names=[],
-            project_name='notfound',
-            report_type='test3',
-            include_nonspecific_project=True,
-            include_nonspecific_disease=False,
-            include_nonspecific_template=False,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock(copy(mock_ipr_results)),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='test1',
+                disease_match_names=[],
+                project_name='notfound',
+                report_type='test3',
+                include_nonspecific_project=True,
+                include_nonspecific_disease=False,
+                include_nonspecific_template=False,
+            )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[2] == '<p><p>no project</p></p>'
         assert len(summary_lines) == 3
 
     def test_includes_nonspecific_template_matches_when_specified(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='test1',
-            disease_match_names=[],
-            project_name='test2',
-            report_type='notfound',
-            include_nonspecific_project=False,
-            include_nonspecific_disease=False,
-            include_nonspecific_template=True,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock(copy(mock_ipr_results)),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='test1',
+                disease_match_names=[],
+                project_name='test2',
+                report_type='notfound',
+                include_nonspecific_project=False,
+                include_nonspecific_disease=False,
+                include_nonspecific_template=True,
+            )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[2] == '<p><p>no template</p></p>'
         assert len(summary_lines) == 3
 
     def test_includes_nonspecific_disease_matches_when_specified(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='notfound',
-            disease_match_names=[],
-            project_name='test2',
-            report_type='test3',
-            include_nonspecific_project=False,
-            include_nonspecific_disease=True,
-            include_nonspecific_template=False,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock(copy(mock_ipr_results)),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='notfound',
+                disease_match_names=[],
+                project_name='test2',
+                report_type='test3',
+                include_nonspecific_project=False,
+                include_nonspecific_disease=True,
+                include_nonspecific_template=False,
+            )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[1] == '<h2>ERBB2 amplification (no specific cancer types)</h2>'
         assert summary_lines[2] == '<p><p>no cancerType</p></p>'
         assert len(summary_lines) == 3
 
     def test_includes_all_graphkb_disease_matches(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='notfound',
-            disease_match_names=['TEST1'],
-            project_name='test2',
-            report_type='test3',
-            include_nonspecific_project=False,
-            include_nonspecific_disease=False,
-            include_nonspecific_template=False,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock(copy(mock_ipr_results)),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='notfound',
+                disease_match_names=['TEST1'],
+                project_name='test2',
+                report_type='test3',
+                include_nonspecific_project=False,
+                include_nonspecific_disease=False,
+                include_nonspecific_template=False,
+            )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[1] == '<h2>ERBB2 amplification (test1,test)</h2>'
         assert summary_lines[2] == '<p><p>normal</p></p>'
         assert len(summary_lines) == 3
 
     def test_prepare_section_for_multiple_variants(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
         # NB this test relies on matches being processed in this order
         matches = [{'kbVariant': 'ERBB2 amplification'}, {'kbVariant': 'second variant'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='test1',
-            disease_match_names=[],
-            project_name='test2',
-            report_type='test3',
-            include_nonspecific_project=False,
-            include_nonspecific_disease=False,
-            include_nonspecific_template=False,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock(copy(mock_ipr_results)),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='test1',
+                disease_match_names=[],
+                project_name='test2',
+                report_type='test3',
+                include_nonspecific_project=False,
+                include_nonspecific_disease=False,
+                include_nonspecific_template=False,
+            )
         summary_lines = ipr_summary.split('\n')
         assert len(summary_lines) == 5
         assert (
@@ -367,17 +412,21 @@ class TestVariantTextFromIPR:
         )
 
     def test_empty_section_when_no_variant_match(self):
-        ipr_conn = MagicMock(get=MagicMock(side_effect=[[], []]))
         matches = [{'kbVariant': 'notfound1'}, {'kbVariant': 'notfound2'}]
-        ipr_summary = get_ipr_analyst_comments(
-            ipr_conn,
-            matches=matches,
-            disease_name='test1',
-            disease_match_names=[],
-            project_name='test2',
-            report_type='test3',
-            include_nonspecific_project=False,
-            include_nonspecific_disease=False,
-            include_nonspecific_template=False,
-        )
+        with patch(
+            'pori_python.ipr.connection.requests.request',
+            make_ipr_get_mock([[], []]),
+        ):
+            ipr_conn = IprConnection('user', 'pass')
+            ipr_summary = get_ipr_analyst_comments(
+                ipr_conn,
+                matches=matches,
+                disease_name='test1',
+                disease_match_names=[],
+                project_name='test2',
+                report_type='test3',
+                include_nonspecific_project=False,
+                include_nonspecific_disease=False,
+                include_nonspecific_template=False,
+            )
         assert ipr_summary == no_comments_found_output

--- a/tests/test_ipr/test_summary.py
+++ b/tests/test_ipr/test_summary.py
@@ -1,5 +1,9 @@
+import os
 from copy import copy
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+
+import jsonschema
+import pytest
 
 from pori_python.ipr.connection import IprConnection
 from pori_python.ipr.summary import (
@@ -8,6 +12,8 @@ from pori_python.ipr.summary import (
     get_preferred_drug_representation,
     substitute_sentence_template,
 )
+
+from .constants import EXCLUDE_INTEGRATION_TESTS
 
 
 class TestGetPreferredDrugRepresentation:
@@ -203,33 +209,65 @@ mock_ipr_results = [
 no_comments_found_output = 'No comments found in IPR for variants in this report'
 
 
-def make_ipr_get_mock(results):
-    """Build a requests.request mock so IprConnection.get() runs for real against fake HTTP responses."""
-    responses = [
-        MagicMock(json=MagicMock(return_value=r), raise_for_status=MagicMock()) for r in results
-    ]
-    return MagicMock(side_effect=responses)
+def validate_mock_ipr_results_against_schema(schema, results):
+    # Since the IPR generated schema has required fields, but the purpose of the test is to prevent
+    # schema drift and not to validate POST payloads to variant-text, we create a custom validator
+    # that ignores the required fields and only validates the properties that are defined in the schema.
+    custom_validators = dict(jsonschema.Draft7Validator.VALIDATORS)
+    custom_validators.pop('required', None)
+    non_required_validator = jsonschema.validators.create(
+        meta_schema=jsonschema.Draft7Validator.META_SCHEMA,
+        validators=custom_validators,
+        version='draft7-lazy',
+    )
+    validator = non_required_validator(schema)
+    declared_properties = set(schema.get('properties', {}))
+
+    for group_index, group in enumerate(results):
+        for record_index, record in enumerate(group):
+            location = f'group {group_index} record {record_index}'
+            unknown = sorted(set(record) - declared_properties)
+            assert not unknown, (
+                f'{location}: properties {unknown} are not defined in the IPR variant-text schema'
+            )
+            errors = sorted(validator.iter_errors(record), key=lambda err: list(err.path))
+            assert not errors, f'{location}: ' + '; '.join(
+                f'{list(err.path)}: {err.message}' for err in errors
+            )
+
+
+def make_ipr_connection():
+    return IprConnection(
+        username=os.environ.get('IPR_USER', os.environ['USER']),
+        password=os.environ['IPR_PASS'],
+        url=os.environ['IPR_TEST_URL'],
+    )
+
+
+# DEVSU-3011 adding IPR integration test to validate variant text schema from the IPR API side to prevent schema drift
+@pytest.mark.skipif(EXCLUDE_INTEGRATION_TESTS, reason='excluding long running integration tests')
+class TestVariantTextSchema:
+    def test_mock_ipr_results_match_variant_text_schema(self):
+        ipr_conn = make_ipr_connection()
+        schema = ipr_conn.get('variant-text/schema')
+        validate_mock_ipr_results_against_schema(schema, mock_ipr_results)
 
 
 class TestVariantTextFromIPR:
     def test_gets_fully_matched_output_when_possible(self):
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock(copy(mock_ipr_results)),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='test1',
-                disease_match_names=[],
-                project_name='test2',
-                report_type='test3',
-                include_nonspecific_project=False,
-                include_nonspecific_disease=True,
-                include_nonspecific_template=True,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            disease_match_names=[],
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=True,
+            include_nonspecific_template=True,
+        )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[1] == '<h2>ERBB2 amplification (test1,test)</h2>'
         assert summary_lines[2] == '<p><p>normal</p></p>'
@@ -237,126 +275,102 @@ class TestVariantTextFromIPR:
 
     def test_omits_nonspecific_project_matches_when_specified(self):
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock(copy(mock_ipr_results)),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='test1',
-                disease_match_names=[],
-                project_name='notfound',
-                report_type='test3',
-                include_nonspecific_project=False,
-                include_nonspecific_disease=True,
-                include_nonspecific_template=True,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            disease_match_names=[],
+            project_name='notfound',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=True,
+            include_nonspecific_template=True,
+        )
         assert ipr_summary == no_comments_found_output
 
     def test_omits_nonspecific_template_matches_when_specified(self):
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock(copy(mock_ipr_results)),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='test1',
-                disease_match_names=[],
-                project_name='test2',
-                report_type='notfound',
-                include_nonspecific_project=True,
-                include_nonspecific_disease=True,
-                include_nonspecific_template=False,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            disease_match_names=[],
+            project_name='test2',
+            report_type='notfound',
+            include_nonspecific_project=True,
+            include_nonspecific_disease=True,
+            include_nonspecific_template=False,
+        )
         assert ipr_summary == no_comments_found_output
 
     def test_omits_nonspecific_disease_matches_when_specified(self):
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock(copy(mock_ipr_results)),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='notfound',
-                disease_match_names=[],
-                project_name='test2',
-                report_type='test3',
-                include_nonspecific_project=True,
-                include_nonspecific_disease=False,
-                include_nonspecific_template=True,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='notfound',
+            disease_match_names=[],
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=True,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=True,
+        )
         assert ipr_summary == no_comments_found_output
 
     def test_includes_nonspecific_project_matches_when_specified(self):
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock(copy(mock_ipr_results)),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='test1',
-                disease_match_names=[],
-                project_name='notfound',
-                report_type='test3',
-                include_nonspecific_project=True,
-                include_nonspecific_disease=False,
-                include_nonspecific_template=False,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            disease_match_names=[],
+            project_name='notfound',
+            report_type='test3',
+            include_nonspecific_project=True,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=False,
+        )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[2] == '<p><p>no project</p></p>'
         assert len(summary_lines) == 3
 
     def test_includes_nonspecific_template_matches_when_specified(self):
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock(copy(mock_ipr_results)),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='test1',
-                disease_match_names=[],
-                project_name='test2',
-                report_type='notfound',
-                include_nonspecific_project=False,
-                include_nonspecific_disease=False,
-                include_nonspecific_template=True,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='test1',
+            disease_match_names=[],
+            project_name='test2',
+            report_type='notfound',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=True,
+        )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[2] == '<p><p>no template</p></p>'
         assert len(summary_lines) == 3
 
     def test_includes_nonspecific_disease_matches_when_specified(self):
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock(copy(mock_ipr_results)),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='notfound',
-                disease_match_names=[],
-                project_name='test2',
-                report_type='test3',
-                include_nonspecific_project=False,
-                include_nonspecific_disease=True,
-                include_nonspecific_template=False,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='notfound',
+            disease_match_names=[],
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=True,
+            include_nonspecific_template=False,
+        )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[1] == '<h2>ERBB2 amplification (no specific cancer types)</h2>'
         assert summary_lines[2] == '<p><p>no cancerType</p></p>'
@@ -364,22 +378,18 @@ class TestVariantTextFromIPR:
 
     def test_includes_all_graphkb_disease_matches(self):
         matches = [{'kbVariant': 'ERBB2 amplification'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock(copy(mock_ipr_results)),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='notfound',
-                disease_match_names=['TEST1'],
-                project_name='test2',
-                report_type='test3',
-                include_nonspecific_project=False,
-                include_nonspecific_disease=False,
-                include_nonspecific_template=False,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='notfound',
+            disease_match_names=['TEST1'],
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=False,
+        )
         summary_lines = ipr_summary.split('\n')
         assert summary_lines[1] == '<h2>ERBB2 amplification (test1,test)</h2>'
         assert summary_lines[2] == '<p><p>normal</p></p>'
@@ -388,22 +398,18 @@ class TestVariantTextFromIPR:
     def test_prepare_section_for_multiple_variants(self):
         # NB this test relies on matches being processed in this order
         matches = [{'kbVariant': 'ERBB2 amplification'}, {'kbVariant': 'second variant'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock(copy(mock_ipr_results)),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='test1',
-                disease_match_names=[],
-                project_name='test2',
-                report_type='test3',
-                include_nonspecific_project=False,
-                include_nonspecific_disease=False,
-                include_nonspecific_template=False,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=copy(mock_ipr_results)))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='notfound',
+            disease_match_names=['TEST1'],
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=False,
+        )
         summary_lines = ipr_summary.split('\n')
         assert len(summary_lines) == 5
         assert (
@@ -413,20 +419,16 @@ class TestVariantTextFromIPR:
 
     def test_empty_section_when_no_variant_match(self):
         matches = [{'kbVariant': 'notfound1'}, {'kbVariant': 'notfound2'}]
-        with patch(
-            'pori_python.ipr.connection.requests.request',
-            make_ipr_get_mock([[], []]),
-        ):
-            ipr_conn = IprConnection('user', 'pass')
-            ipr_summary = get_ipr_analyst_comments(
-                ipr_conn,
-                matches=matches,
-                disease_name='test1',
-                disease_match_names=[],
-                project_name='test2',
-                report_type='test3',
-                include_nonspecific_project=False,
-                include_nonspecific_disease=False,
-                include_nonspecific_template=False,
-            )
+        mock_ipr_conn = MagicMock(get=MagicMock(side_effect=[[], []]))
+        ipr_summary = get_ipr_analyst_comments(
+            mock_ipr_conn,
+            matches=matches,
+            disease_name='notfound',
+            disease_match_names=['TEST1'],
+            project_name='test2',
+            report_type='test3',
+            include_nonspecific_project=False,
+            include_nonspecific_disease=False,
+            include_nonspecific_template=False,
+        )
         assert ipr_summary == no_comments_found_output


### PR DESCRIPTION
- DEVSU-3011
- Update get_ipr_analyst_comments method with 'projects' key in queried variant-text being a list instead of single value (since projects and variant texts now have many-to-many relationship https://github.com/bcgsc/pori_ipr_api/pull/499)
- Update project name matching logic to new projects data structure
- Update summary test to include integrated test to IPR API to validate mock IPR result schema with actual variant text schema from IPR

Requires IPR API PR: https://github.com/bcgsc/pori_ipr_api/pull/516