### PR TITLE
DEVSU-3013 Return variantType and variant key when creating key alterations

### DIFF
--- a/pori_python/ipr/ipr.py
+++ b/pori_python/ipr/ipr.py
@@ -322,15 +322,22 @@ def create_key_alterations(
 
         counts[type_mapping[variant_type]].add(variant_key)
 
-        if variant_type == 'exp':
-            alterations.append(f'{variant.get("gene", "")} ({variant.get("expressionState")})')
-        elif variant_type == 'cnv':
-            alterations.append(f'{variant.get("gene", "")} ({variant.get("cnvState")})')
-        # only show germline if relevant
-        elif kb_match['category'] in GERMLINE_BASE_TERMS and variant.get('germline'):
-            alterations.append(f'germline {variant["variant"]}')
+        if kb_match['category'] in GERMLINE_BASE_TERMS:
+            # only include germline-category matches when the observed variant is germline
+            if variant.get('germline'):
+                alterations.append(
+                    {
+                        "variantType": variant_type,
+                        "variant": variant['key'],
+                    },
+                )
         else:
-            alterations.append(variant['variant'])
+            alterations.append(
+                {
+                    "variantType": variant_type,
+                    "variant": variant['key'],
+                },
+            )
 
     counted_variants = set.union(*counts.values())
     counts['variantsUnknown'] = set()
@@ -340,8 +347,17 @@ def create_key_alterations(
         if variant['variant'] and variant['key'] not in counted_variants:
             counts['variantsUnknown'].add(variant['key'])
 
+    unique_alterations = []
+    seen = set()
+    for alt in alterations:
+        dedupe_key = (alt['variantType'], alt['variant'])
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        unique_alterations.append(alt)
+
     return (
-        [{'geneVariant': alt} for alt in set(alterations)],
+        unique_alterations,
         {k: len(v) for k, v in counts.items()},
     )
 

--- a/pori_python/ipr/ipr.py
+++ b/pori_python/ipr/ipr.py
@@ -327,15 +327,15 @@ def create_key_alterations(
             if variant.get('germline'):
                 alterations.append(
                     {
-                        "variantType": variant_type,
-                        "variant": variant['key'],
+                        'variantType': variant_type,
+                        'variant': variant['key'],
                     },
                 )
         else:
             alterations.append(
                 {
-                    "variantType": variant_type,
-                    "variant": variant['key'],
+                    'variantType': variant_type,
+                    'variant': variant['key'],
                 },
             )
 

--- a/tests/test_ipr/test_ipr.py
+++ b/tests/test_ipr/test_ipr.py
@@ -1034,3 +1034,9 @@ class TestKbMatchSectionPrep:
         # partial matches is false
         assert len(key_alts1) == 3
         assert len(key_alts2) == 4
+        assert {(alt['variantType'], alt['variant']) for alt in key_alts1} == {
+            (variant['variantType'], variant['key']) for variant in ALL_VARIANTS[:3]
+        }
+        assert {(alt['variantType'], alt['variant']) for alt in key_alts2} == {
+            (variant['variantType'], variant['key']) for variant in ALL_VARIANTS[:4]
+        }


### PR DESCRIPTION
- DEVSU-3013
- Return variantType and variant key when creating new key alterations instead of hardcoded variant display names, so IPR API can look for associated variant and create association during report creation process

Works in tandem with IPR API changes: https://github.com/bcgsc/pori_ipr_api/pull/513